### PR TITLE
Fix shell boolean

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -19,3 +19,7 @@ jobs:
       run: ./autogen.sh
     - name: make
       run: make
+    - name: mkdir
+      run: mkdir fakeroot
+    - name: make install
+      run: DESTDIR=$PWD/fakeroot make install

--- a/configure.ac
+++ b/configure.ac
@@ -22,7 +22,7 @@ dnl 	      AS_HELP_STRING([--disable-update-mimedb],
 dnl 			     [disable the update-mime-database after install [default=no]]),,
 dnl 			     enable_update_mimedb=yes)
 dnl AM_CONDITIONAL(ENABLE_UPDATE_MIMEDB, test x$enable_update_mimedb = xyes)
-AM_CONDITIONAL(ENABLE_UPDATE_MIMEDB, no)
+AM_CONDITIONAL(ENABLE_UPDATE_MIMEDB, false)
 
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT


### PR DESCRIPTION
In 79ce828, `ENABLE_UPDATE_MIMEDB` was unconditionally set to `no`, but the negative boolean value in UNIX shell is `false` (while `no` doesn't exist at all on my system).  Somehow, when I tried to build this (on latest Arch Linux) from a clean checkout, `if no` in the (generated) `configure` script executed the true branch, setting `ENABLE_UPDATE_MIMEDB_TRUE` to the empty string.  This enabled the invocation of `$(UPDATE_MIME_DATABASE)` in the generated Makefile during `install`, but the part of `configure.ac` that was supposed to set this variable was commented out, so the build broke.

Frankly, I’ve no idea how and why this was building successfully in CI before this fix.